### PR TITLE
Allow specifying of twilio API URL and API key

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,6 +45,14 @@ well:
 Settings
 --------
 
+.. setting:: OTP_TWILIO_URL
+
+**OTP_TWILIO_URL**
+
+Default: ``"https://api.twilio.com""``
+
+Twilio API URL. This can be used to change edge location
+
 .. setting:: OTP_TWILIO_ACCOUNT
 
 **OTP_TWILIO_ACCOUNT**
@@ -53,6 +61,14 @@ Default: ``None``
 
 Your Twilio account ID.
 
+.. setting:: OTP_TWILIO_API_KEY
+
+**OTP_TWILIO_API_KEY**
+
+Default: ``None``
+
+Your Twilio API key, if no API key is specified requests are made using the Twilio Account ID.
+
 
 .. setting:: OTP_TWILIO_AUTH
 
@@ -60,7 +76,7 @@ Your Twilio account ID.
 
 Default: ``None``
 
-Your Twilio auth token.
+Your Twilio auth token used for API requests. (Either API Key token or account auth token)
 
 
 .. setting:: OTP_TWILIO_CHALLENGE_MESSAGE

--- a/src/otp_twilio/conf.py
+++ b/src/otp_twilio/conf.py
@@ -9,7 +9,9 @@ class Settings(object):
     values if they are not specified by the configuration.
     """
     _defaults = {
+        'OTP_TWILIO_URL': "https://api.twilio.com",
         'OTP_TWILIO_ACCOUNT': None,
+        'OTP_TWILIO_API_KEY': None,
         'OTP_TWILIO_AUTH': None,
         'OTP_TWILIO_CHALLENGE_MESSAGE': "Sent by SMS",
         'OTP_TWILIO_FROM': None,

--- a/src/otp_twilio/models.py
+++ b/src/otp_twilio/models.py
@@ -77,7 +77,7 @@ class TwilioSMSDevice(ThrottlingMixin, SideChannelDevice):
     def _deliver_token(self, token):
         self._validate_config()
 
-        url = 'https://api.twilio.com/2010-04-01/Accounts/{0}/Messages.json'.format(settings.OTP_TWILIO_ACCOUNT)
+        url = '{0}/2010-04-01/Accounts/{1}/Messages.json'.format(settings.OTP_TWILIO_URL, settings.OTP_TWILIO_ACCOUNT)
         data = {
             'From': settings.OTP_TWILIO_FROM,
             'To': self.number,
@@ -86,7 +86,7 @@ class TwilioSMSDevice(ThrottlingMixin, SideChannelDevice):
 
         response = requests.post(
             url, data=data,
-            auth=(settings.OTP_TWILIO_ACCOUNT, settings.OTP_TWILIO_AUTH)
+            auth=(settings.TWILIO_API_KEY if settings.TWILIO_API_KEY else settings.OTP_TWILIO_ACCOUNT, settings.OTP_TWILIO_AUTH)
         )
 
         try:


### PR DESCRIPTION
This allows setting:
- A twilio API key for requests in addition to just the basic account auth
- API URL so you can point to specific regions/edge servers