### PR TITLE
OTP_TWILIO_MESSAGING_SERVICE_SID setting

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -102,6 +102,17 @@ The phone number to send SMS messages from. This must be one of your Twilio
 numbers.
 
 
+.. setting:: OTP_TWILIO_MESSAGING_SERVICE_SID
+
+**OTP_TWILIO_MESSAGING_SERVICE_SID**
+
+Default: ``None``
+
+The Twilio messaging service SID to send SMS messages from. This must be one of
+your Twilio messaging services. If supplied, this takes precedence over
+``OTP_TWILIO_FROM``.
+
+
 .. setting:: OTP_TWILIO_NO_DELIVERY
 
 **OTP_TWILIO_NO_DELIVERY**

--- a/src/otp_twilio/conf.py
+++ b/src/otp_twilio/conf.py
@@ -15,6 +15,7 @@ class Settings(object):
         'OTP_TWILIO_AUTH': None,
         'OTP_TWILIO_CHALLENGE_MESSAGE': "Sent by SMS",
         'OTP_TWILIO_FROM': None,
+        'OTP_TWILIO_MESSAGING_SERVICE_SID': None,
         'OTP_TWILIO_NO_DELIVERY': False,
         'OTP_TWILIO_THROTTLE_FACTOR': 1,
         'OTP_TWILIO_TOKEN_TEMPLATE': '{token}',

--- a/src/otp_twilio/models.py
+++ b/src/otp_twilio/models.py
@@ -79,10 +79,13 @@ class TwilioSMSDevice(ThrottlingMixin, SideChannelDevice):
 
         url = '{0}/2010-04-01/Accounts/{1}/Messages.json'.format(settings.OTP_TWILIO_URL, settings.OTP_TWILIO_ACCOUNT)
         data = {
-            'From': settings.OTP_TWILIO_FROM,
             'To': self.number,
             'Body': str(token),
         }
+        if settings.OTP_TWILIO_MESSAGING_SERVICE_SID:
+            data['MessagingServiceSid'] = settings.OTP_TWILIO_MESSAGING_SERVICE_SID
+        else:
+            data['From'] = settings.OTP_TWILIO_FROM
 
         response = requests.post(
             url, data=data,


### PR DESCRIPTION
Proposed `OTP_TWILIO_MESSAGING_SERVICE_SID` setting that, when provided, sends from the designated Twilio messaging service and lets Twilio pick the sender SMS number instead of providing a single number.

[Twilio docs](https://www.twilio.com/docs/messaging/services/services-send-messages?code-sample=code-send-a-message-with-a-messaging-service&code-language=curl&code-sdk-version=json)

We recently ran into an issue with sending OTP codes to UK (+44) numbers with our toll-free US number - UK providers have blocked SMS messages from US long code numbers. It looks like the way around this is to send from a messaging service with numbers from multiple regions.