### PR TITLE
OTP_TWILIO_VERIFY_SERVICE_SID setting

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -103,6 +103,18 @@ The phone number to send SMS messages from. This must be one of your Twilio
 numbers.
 
 
+.. setting:: OTP_TWILIO_VERIFY_SERVICE_SID
+
+**OTP_TWILIO_VERIFY_SERVICE_SID**
+
+Default: ``None``
+
+The Twilio Verify service SID to send SMS messages from. This must be one of
+your Twilio Verify services. The service must be configured to allow custom
+codes. If supplied, this takes precedence over ``OTP_TWILIO_FROM`` or
+``OTP_TWILIO_MESSAGING_SERVICE_SID``.
+
+
 .. setting:: OTP_TWILIO_MESSAGING_SERVICE_SID
 
 **OTP_TWILIO_MESSAGING_SERVICE_SID**

--- a/src/otp_twilio/conf.py
+++ b/src/otp_twilio/conf.py
@@ -17,6 +17,7 @@ class Settings(object):
         'OTP_TWILIO_CHALLENGE_MESSAGE': "Sent by SMS",
         'OTP_TWILIO_FROM': None,
         'OTP_TWILIO_MESSAGING_SERVICE_SID': None,
+        'OTP_TWILIO_VERIFY_SERVICE_SID': None,
         'OTP_TWILIO_NO_DELIVERY': False,
         'OTP_TWILIO_THROTTLE_FACTOR': 1,
         'OTP_TWILIO_TOKEN_TEMPLATE': '{token}',

--- a/src/otp_twilio/models.py
+++ b/src/otp_twilio/models.py
@@ -136,7 +136,7 @@ class TwilioSMSDevice(ThrottlingMixin, SideChannelDevice):
         self._validate_config()
 
         if settings.OTP_TWILIO_VERIFY_SERVICE_SID:
-            response = self._deliver_twilio_verify_message(token)
+            response = self._deliver_twilio_verify_message(self.token)
         else:
             response = self._deliver_twilio_sms_message(token)
 


### PR DESCRIPTION
Proposed `OTP_TWILIO_VERIFY_SERVICE_SID` setting. If defined, send 2FA codes with Twilio's [Verify API](https://www.twilio.com/docs/verify/api/customization-options#submit-feedback-by-manually-approving-a-verification).

Messages come from a Twilio-controlled number and thus have full international support.